### PR TITLE
added stage name to config schema

### DIFF
--- a/python/lsst/ts/linearstage/config_schema.py
+++ b/python/lsst/ts/linearstage/config_schema.py
@@ -47,12 +47,15 @@ properties:
                 - ZaberV2
         stage_config:
             type: object
+        stage_name:
+            type: string
     required:
         - sal_index
         - target_position_minimum
         - target_position_maximum
         - stage_type
         - stage_config
+        - stage_name
     additionalProperties: false
 required:
     - instances

--- a/python/lsst/ts/linearstage/config_schema.py
+++ b/python/lsst/ts/linearstage/config_schema.py
@@ -47,15 +47,12 @@ properties:
                 - ZaberV2
         stage_config:
             type: object
-        stage_name:
-            type: string
     required:
         - sal_index
         - target_position_minimum
         - target_position_maximum
         - stage_type
         - stage_config
-        - stage_name
     additionalProperties: false
 required:
     - instances

--- a/python/lsst/ts/linearstage/controllers/zaber_lst.py
+++ b/python/lsst/ts/linearstage/controllers/zaber_lst.py
@@ -207,10 +207,13 @@ class ZaberV2(Stage):
                 type: number
             daisy_chain_address:
                 type: integer
+            stage_name:
+                type: string
         required:
             - hostname
             - port
             - daisy_chain_address
+            - stage_name
         additionalProperties: false
         """
         return yaml.safe_load(config_schema)

--- a/tests/data/config/_init.yaml
+++ b/tests/data/config/_init.yaml
@@ -34,3 +34,5 @@ instances:
       hostname: 127.0.0.1
       port: 9000
       daisy_chain_address: 1
+      stage_name: simulation
+

--- a/tests/data/config/zaber.yaml
+++ b/tests/data/config/zaber.yaml
@@ -10,3 +10,4 @@ instances:
       serial_port: /dev/ttyLinearStage1
       steps_per_mm: 8000
       daisy_chain_address: 1
+


### PR DESCRIPTION
Want a way to better differentiate the Zaber stages by name.